### PR TITLE
feature: desacoplar envío de notificaciones por correo al generar ca…

### DIFF
--- a/php/consultas/dao_consultas.php
+++ b/php/consultas/dao_consultas.php
@@ -486,6 +486,7 @@ class dao_consultas
                       ,nombre
                       ,nombre_corto
                       ,observaciones
+                      ,notifica_mail
 				FROM cargo_cuenta_corriente
                 $where
 			   ";
@@ -2038,5 +2039,24 @@ class dao_consultas
                 WHERE id_transaccion_cc = $id";
         toba::db()->ejecutar($sql);
     }
+
+    public static function get_tutor_notificacion_cargo($id_persona)
+    {
+        $sql = "SELECT p_tut.apellidos || ', ' || p_tut.nombres AS tutor
+                       ,p_tut.correo_electronico AS tutor_email
+                FROM persona p_est
+                    JOIN alumno al ON p_est.id_persona = al.id_persona
+                    JOIN persona_allegado pa ON al.id_alumno = pa.id_alumno
+                        AND pa.id_persona_allegado = (
+                            SELECT MIN(id_persona_allegado)
+                            FROM persona_allegado
+                            WHERE id_alumno = al.id_alumno AND tutor = 'S' AND activo = 'S'
+                        )
+                    JOIN persona p_tut ON pa.id_persona = p_tut.id_persona
+                WHERE p_est.id_persona = " . toba::db()->quote($id_persona);
+        return toba::db()->consultar_fila($sql);
+    }
+
+
 }
 ?>

--- a/php/gestion_archivos_cobros/generar_cargos_alumnos/cn_generar_cargos_alumnos.php
+++ b/php/gestion_archivos_cobros/generar_cargos_alumnos/cn_generar_cargos_alumnos.php
@@ -336,7 +336,7 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
         $mensaje .= "Total de cargos no generados: {$this->resumen['cargos_no_generados']}";
 
         if (dao_consultas::catalogo_de_parametros("envia_notif_al_generar_cargo") == 'SI') {
-            $mensaje .= "<br />Total de correos encolados: {$this->resumen['correos_encolados']}";
+            $mensaje .= "<br />Total de correos encolados: " . ($this->resumen['correos_encolados'] ?? 0);
         }
 
         //Agrego mensajes adicionales si existen

--- a/php/gestion_archivos_cobros/generar_cargos_alumnos/cn_generar_cargos_alumnos.php
+++ b/php/gestion_archivos_cobros/generar_cargos_alumnos/cn_generar_cargos_alumnos.php
@@ -33,6 +33,7 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
         $this->resumen['total_alumnos'] = 0;
         $this->resumen['cargos_generados'] = 0;
         $this->resumen['cargos_no_generados'] = 0;
+        $this->notificaciones = array();
 
         if (isset($this->datos_formulario)) {
             if ((is_array($this->datos_formulario['id_persona'])) && ($this->datos_formulario['forma_generacion'] == 'G')) {
@@ -44,6 +45,7 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
             } else {
                 throw new toba_error("Ha ocurrido un error en la generación de los cargos a alumnos, revise los datos ingresados o contáctese con un administrador del sistema.");
             }
+            $this->enviar_notificaciones_acumuladas();
             $this->mostrar_resumen();
         }
     }
@@ -298,6 +300,11 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
         //Valido si el cargo se generó o no
         if (empty($resultado['error'])) {
             $this->resumen['cargos_generados']++;
+            if ($this->tipo_procesamiento == 'Individual') {
+                $this->enviar_notificacion_cargo($persona);
+            } else {
+                $this->acumular_notificacion_cargo($persona);
+            }
         } else {
             $this->resumen['cargos_no_generados']++;
         }
@@ -328,6 +335,10 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
         $mensaje .= "Total de cargos generados: {$this->resumen['cargos_generados']}<br />";
         $mensaje .= "Total de cargos no generados: {$this->resumen['cargos_no_generados']}";
 
+        if (dao_consultas::catalogo_de_parametros("envia_notif_al_generar_cargo") == 'SI') {
+            $mensaje .= "<br />Total de correos encolados: {$this->resumen['correos_encolados']}";
+        }
+
         //Agrego mensajes adicionales si existen
         if (!empty($this->resumen['mensajes'])) {
             $mensaje .= "<br /><br /><strong>Observaciones:</strong><ul>";
@@ -338,6 +349,245 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
         }
 
         toba::notificacion()->agregar($mensaje, 'info');
+    }
+
+    private function enviar_notificacion_cargo($persona)
+    {
+        if (dao_consultas::catalogo_de_parametros("envia_notif_al_generar_cargo") != 'SI') {
+            return;
+        }
+
+        $tutor_data = dao_consultas::get_tutor_notificacion_cargo($persona->get_id_persona());
+        if (empty($tutor_data) || empty($tutor_data['tutor_email'])) {
+            return;
+        }
+        $tutor_email = $tutor_data['tutor_email'];
+        $tutor_nombre = $tutor_data['tutor'];
+
+        $todos_cargos = dao_consultas::get_cargos_cuenta_corriente();
+        $cargo_map = array();
+        foreach ($todos_cargos as $c) {
+            $cargo_map[$c['id_cargo_cuenta_corriente']] = $c['nombre'];
+        }
+        $cargo_nombre = $cargo_map[$this->tipo_cargo] ?? '';
+
+        $importe = $this->datos_formulario['importe_cuota'] ?? 0;
+        $periodo = $this->datos_formulario['cuota'] ?? '';
+        $anio = $this->datos_formulario['anio'] ?? '';
+        $cuota_completa = $persona->get_cuota_completa();
+        if ($cuota_completa && strlen($cuota_completa) == 6) {
+            $meses = array(
+                '01' => 'Enero', '02' => 'Febrero', '03' => 'Marzo', '04' => 'Abril',
+                '05' => 'Mayo', '06' => 'Junio', '07' => 'Julio', '08' => 'Agosto',
+                '09' => 'Septiembre', '10' => 'Octubre', '11' => 'Noviembre', '12' => 'Diciembre'
+            );
+            $mes_nro = substr($cuota_completa, 0, 2);
+            $anio_str = substr($cuota_completa, 2);
+            $mes_nombre = isset($meses[$mes_nro]) ? $meses[$mes_nro] : '';
+            if ($mes_nombre) {
+                $periodo = $mes_nombre . ' / ' . $anio_str;
+            }
+        } elseif ($cuota_completa && $anio) {
+            $periodo = $anio;
+        }
+        $descripcion = $cargo_nombre . ($periodo ? ' (' . $periodo . ')' : '');
+
+        $fecha = new fecha();
+        $fecha_generacion = $fecha->get_timestamp_db();
+
+        $nombre_institucion = dao_consultas::catalogo_de_parametros("nombre_institucion");
+
+        $detalle_deuda = array();
+        if (dao_consultas::catalogo_de_parametros("envia_detalle_deuda_en_correo") == 'SI') {
+            $datos_deuda = $persona->get_datos_deuda_corriente();
+            foreach ($datos_deuda as $item) {
+                $id_cargo = $item['id_cargo_cuenta_corriente'] ?? 0;
+                $concepto = $item['concepto'];
+                if (empty($concepto)) {
+                    $concepto = $cargo_map[$id_cargo] ?? $item['estado_cuota'];
+                }
+                $detalle_deuda[] = array(
+                    'concepto' => $concepto,
+                    'periodo'  => $item['cuota'],
+                    'importe'  => number_format($item['importe'], 2, ',', '.'),
+                    'estado'   => $item['estado_cuota']
+                );
+            }
+        }
+
+        $forma_pago = array();
+        if (dao_consultas::catalogo_de_parametros("envia_forma_pago_en_correo") == 'SI') {
+            $formas_cobro = $persona->get_datos_formas_cobro();
+            foreach ($formas_cobro as $fc) {
+                if (isset($fc['activo']) && $fc['activo'] == 'S') {
+                    $mp = $fc['medio_pago'] ?? '';
+                    if (empty($mp)) {
+                        $mp = $fc['marca_tarjeta'] ?? '';
+                    }
+                    $forma_pago = array(
+                        'medio_pago'      => $mp,
+                        'marca_tarjeta'   => $fc['marca_tarjeta'] ?? '',
+                        'entidad_bancaria' => $fc['entidad_bancaria'] ?? '',
+                    );
+                    break;
+                }
+            }
+        }
+
+        $datos_correo = array(
+            'alumno'           => $persona->get_apellidos() . ', ' . $persona->get_nombres() . ' - Legajo: ' . ($persona->get_legajo() ?? ''),
+            'tutor'            => $tutor_nombre,
+            'cargo_nombre'     => $cargo_nombre,
+            'descripcion'      => $descripcion,
+            'importe'          => number_format($importe, 2, ',', '.'),
+            'fecha_generacion' => $fecha_generacion,
+            'periodo'          => $periodo,
+            'nombre_institucion' => $nombre_institucion,
+            'detalle_deuda'    => $detalle_deuda,
+            'forma_pago'       => $forma_pago,
+        );
+
+        $asunto = envio_correo::generar_asunto_notificacion_cargo();
+        $cuerpo = envio_correo::generar_cuerpo_notificacion_cargo($datos_correo);
+
+        $sql = "INSERT INTO correo_pendiente (email_destino, asunto, cuerpo) VALUES ("
+            . toba::db()->quote($tutor_email) . ", "
+            . toba::db()->quote($asunto) . ", "
+            . toba::db()->quote($cuerpo) . ")";
+        toba::db()->consultar($sql);
+        if (!isset($this->resumen['correos_encolados'])) {
+            $this->resumen['correos_encolados'] = 0;
+        }
+        $this->resumen['correos_encolados']++;
+    }
+
+    private function acumular_notificacion_cargo($persona)
+    {
+        if (dao_consultas::catalogo_de_parametros("envia_notif_al_generar_cargo") != 'SI') {
+            return;
+        }
+
+        $tutor_data = dao_consultas::get_tutor_notificacion_cargo($persona->get_id_persona());
+        if (empty($tutor_data) || empty($tutor_data['tutor_email'])) {
+            return;
+        }
+        $tutor_email = $tutor_data['tutor_email'];
+        $tutor_nombre = $tutor_data['tutor'];
+
+        $todos_cargos = dao_consultas::get_cargos_cuenta_corriente();
+        $cargo_map = array();
+        foreach ($todos_cargos as $c) {
+            $cargo_map[$c['id_cargo_cuenta_corriente']] = $c['nombre'];
+        }
+        $cargo_nombre = $cargo_map[$this->tipo_cargo] ?? '';
+
+        $importe = $this->datos_formulario['importe_cuota'] ?? 0;
+        $periodo = $this->datos_formulario['cuota'] ?? '';
+        $anio = $this->datos_formulario['anio'] ?? '';
+        $cuota_completa = $persona->get_cuota_completa();
+        if ($cuota_completa && strlen($cuota_completa) == 6) {
+            $meses = array(
+                '01' => 'Enero', '02' => 'Febrero', '03' => 'Marzo', '04' => 'Abril',
+                '05' => 'Mayo', '06' => 'Junio', '07' => 'Julio', '08' => 'Agosto',
+                '09' => 'Septiembre', '10' => 'Octubre', '11' => 'Noviembre', '12' => 'Diciembre'
+            );
+            $mes_nro = substr($cuota_completa, 0, 2);
+            $anio_str = substr($cuota_completa, 2);
+            $mes_nombre = isset($meses[$mes_nro]) ? $meses[$mes_nro] : '';
+            if ($mes_nombre) {
+                $periodo = $mes_nombre . ' / ' . $anio_str;
+            }
+        } elseif ($cuota_completa && $anio) {
+            $periodo = $anio;
+        }
+        $descripcion = $cargo_nombre . ($periodo ? ' (' . $periodo . ')' : '');
+
+        $fecha = new fecha();
+        $fecha_generacion = $fecha->get_timestamp_db();
+
+        $detalle_deuda = array();
+        if (dao_consultas::catalogo_de_parametros("envia_detalle_deuda_en_correo") == 'SI') {
+            $datos_deuda = $persona->get_datos_deuda_corriente();
+            foreach ($datos_deuda as $item) {
+                $id_cargo = $item['id_cargo_cuenta_corriente'] ?? 0;
+                $concepto = $item['concepto'];
+                if (empty($concepto)) {
+                    $concepto = $cargo_map[$id_cargo] ?? $item['estado_cuota'];
+                }
+                $detalle_deuda[] = array(
+                    'concepto' => $concepto,
+                    'periodo'  => $item['cuota'],
+                    'importe'  => number_format($item['importe'], 2, ',', '.'),
+                    'estado'   => $item['estado_cuota']
+                );
+            }
+        }
+
+        $forma_pago = array();
+        if (dao_consultas::catalogo_de_parametros("envia_forma_pago_en_correo") == 'SI') {
+            $formas_cobro = $persona->get_datos_formas_cobro();
+            foreach ($formas_cobro as $fc) {
+                if (isset($fc['activo']) && $fc['activo'] == 'S') {
+                    $mp = $fc['medio_pago'] ?? '';
+                    if (empty($mp)) {
+                        $mp = $fc['marca_tarjeta'] ?? '';
+                    }
+                    $forma_pago = array(
+                        'medio_pago'      => $mp,
+                        'marca_tarjeta'   => $fc['marca_tarjeta'] ?? '',
+                        'entidad_bancaria' => $fc['entidad_bancaria'] ?? '',
+                    );
+                    break;
+                }
+            }
+        }
+
+        $alumno_data = array(
+            'alumno'           => $persona->get_apellidos() . ', ' . $persona->get_nombres() . ' - Legajo: ' . ($persona->get_legajo() ?? ''),
+            'cargo_nombre'     => $cargo_nombre,
+            'descripcion'      => $descripcion,
+            'importe'          => number_format($importe, 2, ',', '.'),
+            'fecha_generacion' => $fecha_generacion,
+            'periodo'          => $periodo,
+            'detalle_deuda'    => $detalle_deuda,
+            'forma_pago'       => $forma_pago,
+        );
+
+        if (!isset($this->notificaciones[$tutor_email])) {
+            $this->notificaciones[$tutor_email] = array(
+                'tutor_nombre' => $tutor_nombre,
+                'alumnos' => array(),
+            );
+        }
+        $this->notificaciones[$tutor_email]['alumnos'][] = $alumno_data;
+    }
+
+    private function enviar_notificaciones_acumuladas()
+    {
+        if (empty($this->notificaciones)) {
+            return;
+        }
+
+        $this->resumen['correos_encolados'] = 0;
+        $nombre_institucion = dao_consultas::catalogo_de_parametros("nombre_institucion");
+
+        foreach ($this->notificaciones as $tutor_email => $data) {
+            $datos_correo = array(
+                'tutor'              => $data['tutor_nombre'],
+                'alumnos'            => $data['alumnos'],
+                'nombre_institucion' => $nombre_institucion,
+            );
+
+            $asunto = envio_correo::generar_asunto_notificacion_cargo();
+            $cuerpo = envio_correo::generar_cuerpo_notificacion_cargos_multiples($datos_correo);
+
+            $sql = "INSERT INTO correo_pendiente (email_destino, asunto, cuerpo) VALUES ("
+                . toba::db()->quote($tutor_email) . ", "
+                . toba::db()->quote($asunto) . ", "
+                . toba::db()->quote($cuerpo) . ")";
+            toba::db()->consultar($sql);
+            $this->resumen['correos_encolados']++;
+        }
     }
 
     /**

--- a/php/gestion_archivos_cobros/generar_cargos_alumnos/cn_generar_cargos_alumnos.php
+++ b/php/gestion_archivos_cobros/generar_cargos_alumnos/cn_generar_cargos_alumnos.php
@@ -33,6 +33,8 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
         $this->resumen['total_alumnos'] = 0;
         $this->resumen['cargos_generados'] = 0;
         $this->resumen['cargos_no_generados'] = 0;
+        $this->resumen['alumnos_duplicados'] = array();
+        $this->resumen['alumnos_sin_email'] = array();
         $this->notificaciones = array();
 
         if (isset($this->datos_formulario)) {
@@ -307,6 +309,23 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
             }
         } else {
             $this->resumen['cargos_no_generados']++;
+            if (isset($resultado['id_persona'])) {
+                $filtro = array('id_persona' => $resultado['id_persona'], 'solo_alumnos' => true, 'con_dni' => false);
+                $datos_persona = dao_consultas::get_nombres_persona($filtro);
+                $dni = '';
+                $documentos = $persona->get_documentos();
+                foreach ($documentos as $doc) {
+                    if ($doc['id_tipo_documento'] == 8) {
+                        $dni = $doc['identificacion'];
+                        break;
+                    }
+                }
+                if ($datos_persona) {
+                    $this->resumen['alumnos_duplicados'][] = $datos_persona[0]['nombre_completo'] . ($dni ? ' - DNI ' . $dni : '');
+                } else {
+                    $this->resumen['alumnos_duplicados'][] = $resultado['id_persona'];
+                }
+            }
         }
     }
 
@@ -339,6 +358,24 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
             $mensaje .= "<br />Total de correos encolados: " . ($this->resumen['correos_encolados'] ?? 0);
         }
 
+        //Alumnos que ya tenían el cargo generado
+        if (!empty($this->resumen['alumnos_duplicados'])) {
+            $mensaje .= "<br /><br /><strong>Los siguientes alumnos ya tienen el cargo generado para el período seleccionado:</strong><ul>";
+            foreach ($this->resumen['alumnos_duplicados'] as $dup) {
+                $mensaje .= "<li>{$dup}</li>";
+            }
+            $mensaje .= "</ul>";
+        }
+
+        //Alumnos sin tutor activo con correo electrónico
+        if (!empty($this->resumen['alumnos_sin_email'])) {
+            $mensaje .= "<br /><br /><strong>Los siguientes alumnos no tienen tutor activo con correo electrónico asociado:</strong><ul>";
+            foreach ($this->resumen['alumnos_sin_email'] as $nom) {
+                $mensaje .= "<li>{$nom}</li>";
+            }
+            $mensaje .= "</ul>";
+        }
+
         //Agrego mensajes adicionales si existen
         if (!empty($this->resumen['mensajes'])) {
             $mensaje .= "<br /><br /><strong>Observaciones:</strong><ul>";
@@ -359,6 +396,15 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
 
         $tutor_data = dao_consultas::get_tutor_notificacion_cargo($persona->get_id_persona());
         if (empty($tutor_data) || empty($tutor_data['tutor_email'])) {
+            $dni = '';
+            $documentos = $persona->get_documentos();
+            foreach ($documentos as $doc) {
+                if ($doc['id_tipo_documento'] == 8) {
+                    $dni = $doc['identificacion'];
+                    break;
+                }
+            }
+            $this->resumen['alumnos_sin_email'][] = $persona->get_nombre_completo_persona() . ($dni ? ' - DNI ' . $dni : '');
             return;
         }
         $tutor_email = $tutor_data['tutor_email'];
@@ -469,6 +515,15 @@ class cn_generar_cargos_alumnos extends gestionescuelas_cn
 
         $tutor_data = dao_consultas::get_tutor_notificacion_cargo($persona->get_id_persona());
         if (empty($tutor_data) || empty($tutor_data['tutor_email'])) {
+            $dni = '';
+            $documentos = $persona->get_documentos();
+            foreach ($documentos as $doc) {
+                if ($doc['id_tipo_documento'] == 8) {
+                    $dni = $doc['identificacion'];
+                    break;
+                }
+            }
+            $this->resumen['alumnos_sin_email'][] = $persona->get_nombre_completo_persona() . ($dni ? ' - DNI ' . $dni : '');
             return;
         }
         $tutor_email = $tutor_data['tutor_email'];

--- a/php/gestion_archivos_cobros/generar_cargos_alumnos/eiformulario.php
+++ b/php/gestion_archivos_cobros/generar_cargos_alumnos/eiformulario.php
@@ -5,7 +5,8 @@ class eiformulario extends gestionescuelas_ei_formulario
 	{
 		$importe_mensual_cuota_x_grado = dao_consultas::catalogo_de_parametros("importe_mensual_cuota_x_grado");
 		$ingresa_importe_en_generacion_cargos = dao_consultas::catalogo_de_parametros("ingresa_importe_en_generacion_cargos");
-        $cant_cuotas_cobro_inscripcion = dao_consultas::catalogo_de_parametros("cant_cuotas_cobro_inscripcion");
+		$cant_cuotas_cobro_inscripcion = dao_consultas::catalogo_de_parametros("cant_cuotas_cobro_inscripcion");
+		$envia_notif = dao_consultas::catalogo_de_parametros("envia_notif_al_generar_cargo");
 
 		echo "
 		{$this->objeto_js}.ini = function()
@@ -38,7 +39,11 @@ class eiformulario extends gestionescuelas_ei_formulario
 		{
 			if (!es_inicial) {
 			    if (this.ef('forma_generacion').get_estado() == 'G') {
-			        alert('Tenga en cuenta que al seleccionar la opción Grupal se le generará el costo a todos los alumnos activos cargados en el sistema');
+			        alert('Tenga en cuenta que al seleccionar la opción Grupal se le generará el cargo a todos los alumnos activos cargados en el sistema');
+		        var envia_notif_al_generar_cargo = '{$envia_notif}';
+		        if (envia_notif_al_generar_cargo == 'SI') {
+		            alert('Además, se enviarán correos electrónicos de notificación a cada tutor de los alumnos procesados.');
+		        }
 			        this.ef('id_persona').set_obligatorio(0);
 			        this.ef('id_persona').resetear_estado();
 			        this.ef('id_persona').ocultar();
@@ -73,7 +78,7 @@ class eiformulario extends gestionescuelas_ei_formulario
 			        }
 			        
 			        if ((cant_cuotas_cobro_inscripcion > 1) && (ingresa_importe_en_generacion_cargos == 'SI')) {
-			            alert('Tenga en cuenta que los valores de las cuotas que va a generar para las inscripciones NO saldrán del importe ingresado por pantalla, sino que se tomará de los parámetros correspondientes:".'\n'." * importe_cuota_uno_nivel_inicial ".'\n'." *importe_cuota_dos_nivel_inicial ".'\n'." *importe_cuota_uno_nivel_primario ".'\n'." *importe_cuota_dos_nivel_primario".'\n'."Se recomienda cambiar a NO el valor del parámetro ingresa_importe_en_generacion_cargos".'\n'."'); 
+			            alert('Tenga en cuenta que los valores de las cuotas que va a generar para las inscripciones NO saldrán del importe ingresado por pantalla, sino que se tomará de los parámetros correspondientes:" . '\n' . " * importe_cuota_uno_nivel_inicial " . '\n' . " *importe_cuota_dos_nivel_inicial " . '\n' . " *importe_cuota_uno_nivel_primario " . '\n' . " *importe_cuota_dos_nivel_primario" . '\n' . "Se recomienda cambiar a NO el valor del parámetro ingresa_importe_en_generacion_cargos" . '\n' . "'); 
 			        }
 			        break;
 				case '2': //cuota mensual
@@ -102,4 +107,3 @@ class eiformulario extends gestionescuelas_ei_formulario
 		";
 	}
 }
-?>

--- a/php/personas/persona.php
+++ b/php/personas/persona.php
@@ -1578,7 +1578,7 @@ class persona
                       ,at.id_entidad_bancaria
                       ,eb.nombre_corto as entidad_bancaria
                       ,at.id_medio_pago
-                      ,mp.nombre_corto as medio_pago
+                      ,mp.nombre as medio_pago
                       ,at.activo
                       ,(CASE WHEN at.activo = 'S' THEN 'Activo'
                              WHEN at.activo = 'N' THEN 'Inactivo'
@@ -2224,8 +2224,7 @@ class persona
             $alumnos_con_error['id_persona'] = $this->persona;
         }
         if (!empty($alumnos_con_error)) {
-            $this->mostrar_mensajes($alumnos_con_error);
-            return ['error' => true, 'mensaje' => 'Cargo no generado: error al validar generación del cargo.'];
+            return ['error' => true, 'mensaje' => 'Cargo no generado: error al validar generación del cargo.', 'id_persona' => $this->persona];
         } else {
             toba::notificacion()->agregar('Los cargos en los alumnos fueron generados con éxito.', 'info');
             return ['error' => false];

--- a/php/personas/persona.php
+++ b/php/personas/persona.php
@@ -1319,6 +1319,16 @@ class persona
         return $this->ultimo_dia_mes_cuota;
     }
 
+    public function get_descripcion_cuota()
+    {
+        return $this->descripcion_cuota;
+    }
+
+    public function get_cuota_completa()
+    {
+        return $this->cuota_completa;
+    }
+
     //---------------------------------------------------------------------
     //                     MÉTODOS
     //---------------------------------------------------------------------

--- a/php/utiles/envio_correo.php
+++ b/php/utiles/envio_correo.php
@@ -109,6 +109,255 @@ class envio_correo
 
         return $mensaje;
     }
+    public static function generar_asunto_notificacion_cargo()
+    {
+        return 'Nuevo cargo generado - Gestion Escuelas';
+    }
+
+    public static function generar_cuerpo_notificacion_cargo($datos)
+    {
+        $alumno = htmlspecialchars($datos['alumno']);
+        $tutor = htmlspecialchars($datos['tutor']);
+        $cargo_nombre = htmlspecialchars($datos['cargo_nombre']);
+        $descripcion = htmlspecialchars($datos['descripcion']);
+        $importe = htmlspecialchars($datos['importe']);
+        $fecha = htmlspecialchars($datos['fecha_generacion']);
+        $periodo = htmlspecialchars($datos['periodo']);
+
+        $nombre_institucion = htmlspecialchars($datos['nombre_institucion']);
+
+        $detalle_deuda = '';
+        if (!empty($datos['detalle_deuda'])) {
+            $detalle_deuda = '
+                <h3 style="color: #5bc0de; margin-top: 20px;">Detalle de Deuda Actual</h3>
+                <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
+                    <thead>
+                        <tr style="background-color: #5bc0de; color: #fff;">
+                            <th style="padding: 8px; border: 1px solid #ddd;">Concepto</th>
+                            <th style="padding: 8px; border: 1px solid #ddd;">Periodo</th>
+                            <th style="padding: 8px; border: 1px solid #ddd;">Importe</th>
+                            <th style="padding: 8px; border: 1px solid #ddd;">Estado</th>
+                        </tr>
+                    </thead>
+                    <tbody>';
+            foreach ($datos['detalle_deuda'] as $deuda) {
+                $detalle_deuda .= '
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['concepto']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['periodo']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">$ ' . htmlspecialchars($deuda['importe']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['estado']) . '</td>
+                        </tr>';
+            }
+            $detalle_deuda .= '
+                    </tbody>
+                </table>';
+        }
+
+        $forma_pago = '';
+        if (!empty($datos['forma_pago'])) {
+            $forma_pago = '
+                <h3 style="color: #5bc0de; margin-top: 20px;">Forma de Pago Registrada</h3>
+                <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
+                    <tr>
+                        <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Medio de Pago:</strong></td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['medio_pago']) . '</td>
+                    </tr>';
+            if (!empty($datos['forma_pago']['marca_tarjeta'])) {
+                $forma_pago .= '
+                    <tr>
+                        <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Marca:</strong></td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['marca_tarjeta']) . '</td>
+                    </tr>';
+            }
+            if (!empty($datos['forma_pago']['entidad_bancaria'])) {
+                $forma_pago .= '
+                    <tr>
+                        <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Banco/Entidad:</strong></td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['entidad_bancaria']) . '</td>
+                    </tr>';
+            }
+            $forma_pago .= '
+                </table>';
+        }
+
+        $mensaje = '
+            <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto;">
+                <div style="background-color: #5bc0de; color: #fff; padding: 20px; text-align: center; border-radius: 5px 5px 0 0;">
+                    <h2 style="margin: 0;">Nuevo Cargo Generado</h2>
+                </div>
+
+                <div style="padding: 20px; border: 1px solid #ddd; border-top: none;">
+                    <p>Estimado/a <strong>' . $tutor . '</strong>,</p>
+                    <p>Le informamos que se ha generado un nuevo cargo en la cuenta corriente del alumno/a <strong>' . $alumno . '</strong>.</p>
+
+                    <table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Tipo de Cargo:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . $cargo_nombre . '</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Descripcion:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . $descripcion . '</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Periodo:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . $periodo . '</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Importe:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold; color: #d9534f;">$ ' . $importe . '</td>
+                        </tr>
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Fecha de Generacion:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . $fecha . '</td>
+                        </tr>
+                    </table>
+
+                    ' . $detalle_deuda . '
+
+                    ' . $forma_pago . '
+
+                    <p style="margin-top: 20px;">Por favor, le solicitamos se regularice la situación a la brevedad. Si ya ha realizado el pago por otro medio, por favor envíe el comprobante por este medio o por correo para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.</p>
+                    <p>Ante cualquier consulta, no dude en comunicarse con la institución.</p>
+
+                    <hr style="border: 0; border-top: 1px solid #eee; margin: 20px 0;">
+                    <p style="font-size: 12px; color: #999; text-align: center;">' . $nombre_institucion . ' - Sistema de Gestion de Escuelas</p>
+                </div>
+            </div>
+        ';
+
+        return $mensaje;
+    }
+
+
+    public static function generar_asunto_notificacion_cargos_multiples()
+    {
+        return 'Nuevos cargos generados - Gestion Escuelas';
+    }
+
+    public static function generar_cuerpo_notificacion_cargos_multiples($datos)
+    {
+        $tutor = htmlspecialchars($datos['tutor']);
+        $nombre_institucion = htmlspecialchars($datos['nombre_institucion']);
+
+        $alumnos_html = '';
+        foreach ($datos['alumnos'] as $al) {
+            $alumno = htmlspecialchars($al['alumno']);
+            $cargo_nombre = htmlspecialchars($al['cargo_nombre']);
+            $descripcion = htmlspecialchars($al['descripcion']);
+            $importe = htmlspecialchars($al['importe']);
+            $fecha = htmlspecialchars($al['fecha_generacion']);
+            $periodo = htmlspecialchars($al['periodo']);
+
+            $detalle_deuda = '';
+            if (!empty($al['detalle_deuda'])) {
+                $detalle_deuda = '
+                    <h4 style="color: #5bc0de;">Detalle de Deuda Actual</h4>
+                    <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
+                        <thead>
+                            <tr style="background-color: #5bc0de; color: #fff;">
+                                <th style="padding: 8px; border: 1px solid #ddd;">Concepto</th>
+                                <th style="padding: 8px; border: 1px solid #ddd;">Periodo</th>
+                                <th style="padding: 8px; border: 1px solid #ddd;">Importe</th>
+                                <th style="padding: 8px; border: 1px solid #ddd;">Estado</th>
+                            </tr>
+                        </thead>
+                        <tbody>';
+                foreach ($al['detalle_deuda'] as $deuda) {
+                    $detalle_deuda .= '
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['concepto']) . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['periodo']) . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">$ ' . htmlspecialchars($deuda['importe']) . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['estado']) . '</td>
+                            </tr>';
+                }
+                $detalle_deuda .= '
+                        </tbody>
+                    </table>';
+            }
+
+            $forma_pago = '';
+            if (!empty($al['forma_pago'])) {
+                $forma_pago = '
+                    <h4 style="color: #5bc0de;">Forma de Pago Registrada</h4>
+                    <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Medio de Pago:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['medio_pago']) . '</td>
+                        </tr>';
+                if (!empty($al['forma_pago']['marca_tarjeta'])) {
+                    $forma_pago .= '
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Marca:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['marca_tarjeta']) . '</td>
+                        </tr>';
+                }
+                if (!empty($al['forma_pago']['entidad_bancaria'])) {
+                    $forma_pago .= '
+                        <tr>
+                            <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Banco/Entidad:</strong></td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['entidad_bancaria']) . '</td>
+                        </tr>';
+                }
+                $forma_pago .= '
+                    </table>';
+            }
+
+            $alumnos_html .= '
+                    <div style="margin-bottom: 30px; padding: 15px; border: 1px solid #ddd; border-radius: 5px; background-color: #fafafa;">
+                        <h3 style="color: #555; margin-top: 0;">' . $alumno . '</h3>
+                        <table style="width: 100%; border-collapse: collapse;">
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Tipo de Cargo:</strong></td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . $cargo_nombre . '</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Descripcion:</strong></td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . $descripcion . '</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Periodo:</strong></td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . $periodo . '</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Importe:</strong></td>
+                                <td style="padding: 8px; border: 1px solid #ddd; font-weight: bold; color: #d9534f;">$ ' . $importe . '</td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Fecha de Generacion:</strong></td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . $fecha . '</td>
+                            </tr>
+                        </table>
+                        ' . $detalle_deuda . '
+                        ' . $forma_pago . '
+                    </div>';
+        }
+
+        $mensaje = '
+            <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto;">
+                <div style="background-color: #5bc0de; color: #fff; padding: 20px; text-align: center; border-radius: 5px 5px 0 0;">
+                    <h2 style="margin: 0;">Nuevos Cargos Generados</h2>
+                </div>
+
+                <div style="padding: 20px; border: 1px solid #ddd; border-top: none;">
+                    <p>Estimado/a <strong>' . $tutor . '</strong>,</p>
+                    <p>Se han generado los siguientes cargos en las cuentas corrientes de los alumnos a su cargo:</p>
+
+                    ' . $alumnos_html . '
+
+                    <p style="margin-top: 20px;">Por favor, le solicitamos se regularice la situación a la brevedad. Si ya ha realizado el pago por otro medio, por favor envíe el comprobante por este medio o por correo para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.</p>
+                    <p>Ante cualquier consulta, no dude en comunicarse con la institución.</p>
+
+                    <hr style="border: 0; border-top: 1px solid #eee; margin: 20px 0;">
+                    <p style="font-size: 12px; color: #999; text-align: center;">' . $nombre_institucion . ' - Sistema de Gestion de Escuelas</p>
+                </div>
+            </div>
+        ';
+
+        return $mensaje;
+    }
 
     public static function generar_mensaje_whatsapp_rechazo($datos)
     {

--- a/php/utiles/envio_correo.php
+++ b/php/utiles/envio_correo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Clase para manejar el envio de correos electronicos en el Sistema de Gestion de Escuelas.
  */
@@ -7,8 +8,8 @@ class envio_correo
     private $email;
     private $asunto;
     private $cuerpo;
-    private $max_intentos = 3;  
-    private $pausa = 2;         
+    private $max_intentos = 3;
+    private $pausa = 2;
 
     public function __construct($email)
     {
@@ -66,18 +67,27 @@ class envio_correo
 
     public static function generar_cuerpo_notificacion_rechazo($datos)
     {
-        $alumno = htmlspecialchars($datos['alumno']);
+        $alumno = htmlspecialchars($datos['alumno'], ENT_QUOTES, 'ISO-8859-1');
         $cuota_raw = $datos['cuota']; // Viene como MMYYYY
-        $error = htmlspecialchars($datos['descripcion_error_debito']);
-        $tutor = htmlspecialchars($datos['tutor']);
+        $error = htmlspecialchars($datos['descripcion_error_debito'], ENT_QUOTES, 'ISO-8859-1');
+        $tutor = htmlspecialchars($datos['tutor'], ENT_QUOTES, 'ISO-8859-1');
 
         // Formateamos la cuota
         $meses = array(
-            '01' => 'Enero', '02' => 'Febrero', '03' => 'Marzo', '04' => 'Abril',
-            '05' => 'Mayo', '06' => 'Junio', '07' => 'Julio', '08' => 'Agosto',
-            '09' => 'Septiembre', '10' => 'Octubre', '11' => 'Noviembre', '12' => 'Diciembre'
+            '01' => 'Enero',
+            '02' => 'Febrero',
+            '03' => 'Marzo',
+            '04' => 'Abril',
+            '05' => 'Mayo',
+            '06' => 'Junio',
+            '07' => 'Julio',
+            '08' => 'Agosto',
+            '09' => 'Septiembre',
+            '10' => 'Octubre',
+            '11' => 'Noviembre',
+            '12' => 'Diciembre'
         );
-        
+
         $mes_nro = substr($cuota_raw, 0, 2);
         $anio = substr($cuota_raw, 2);
         $mes_nombre = (isset($meses[$mes_nro])) ? $meses[$mes_nro] : 'Mes ' . $mes_nro;
@@ -91,7 +101,7 @@ class envio_correo
                 
                 <table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
                     <tr>
-                        <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Cuota (Mes/A帽o):</strong></td>
+                        <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Cuota (Mes/A駉):</strong></td>
                         <td style="padding: 8px; border: 1px solid #ddd;">' . $cuota . '</td>
                     </tr>
                     <tr>
@@ -116,15 +126,16 @@ class envio_correo
 
     public static function generar_cuerpo_notificacion_cargo($datos)
     {
-        $alumno = htmlspecialchars($datos['alumno']);
-        $tutor = htmlspecialchars($datos['tutor']);
-        $cargo_nombre = htmlspecialchars($datos['cargo_nombre']);
-        $descripcion = htmlspecialchars($datos['descripcion']);
-        $importe = htmlspecialchars($datos['importe']);
-        $fecha = htmlspecialchars($datos['fecha_generacion']);
-        $periodo = htmlspecialchars($datos['periodo']);
+        toba::logger()->error($datos);
+        $alumno = htmlspecialchars($datos['alumno'], ENT_QUOTES, 'ISO-8859-1');
+        $tutor = htmlspecialchars($datos['tutor'], ENT_QUOTES, 'ISO-8859-1');
+        $cargo_nombre = htmlspecialchars($datos['cargo_nombre'], ENT_QUOTES, 'ISO-8859-1');
+        $descripcion = htmlspecialchars($datos['descripcion'], ENT_QUOTES, 'ISO-8859-1');
+        $importe = htmlspecialchars($datos['importe'], ENT_QUOTES, 'ISO-8859-1');
+        $fecha = htmlspecialchars($datos['fecha_generacion'], ENT_QUOTES, 'ISO-8859-1');
+        $periodo = htmlspecialchars($datos['periodo'], ENT_QUOTES, 'ISO-8859-1');
 
-        $nombre_institucion = htmlspecialchars($datos['nombre_institucion']);
+        $nombre_institucion = htmlspecialchars($datos['nombre_institucion'], ENT_QUOTES, 'ISO-8859-1');
 
         $detalle_deuda = '';
         if (!empty($datos['detalle_deuda'])) {
@@ -143,10 +154,10 @@ class envio_correo
             foreach ($datos['detalle_deuda'] as $deuda) {
                 $detalle_deuda .= '
                         <tr>
-                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['concepto']) . '</td>
-                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['periodo']) . '</td>
-                            <td style="padding: 8px; border: 1px solid #ddd;">$ ' . htmlspecialchars($deuda['importe']) . '</td>
-                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['estado']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['concepto'], ENT_QUOTES, 'ISO-8859-1') . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['periodo'], ENT_QUOTES, 'ISO-8859-1') . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">$ ' . htmlspecialchars($deuda['importe'], ENT_QUOTES, 'ISO-8859-1') . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['estado'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                         </tr>';
             }
             $detalle_deuda .= '
@@ -161,20 +172,20 @@ class envio_correo
                 <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
                     <tr>
                         <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Medio de Pago:</strong></td>
-                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['medio_pago']) . '</td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['medio_pago'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                     </tr>';
             if (!empty($datos['forma_pago']['marca_tarjeta'])) {
                 $forma_pago .= '
                     <tr>
                         <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Marca:</strong></td>
-                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['marca_tarjeta']) . '</td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['marca_tarjeta'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                     </tr>';
             }
             if (!empty($datos['forma_pago']['entidad_bancaria'])) {
                 $forma_pago .= '
                     <tr>
                         <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Banco/Entidad:</strong></td>
-                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['entidad_bancaria']) . '</td>
+                        <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($datos['forma_pago']['entidad_bancaria'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                     </tr>';
             }
             $forma_pago .= '
@@ -218,8 +229,8 @@ class envio_correo
 
                     ' . $forma_pago . '
 
-                    <p style="margin-top: 20px;">Por favor, le solicitamos se regularice la situaci贸n a la brevedad. Si ya ha realizado el pago por otro medio, por favor env铆e el comprobante por este medio o por correo para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.</p>
-                    <p>Ante cualquier consulta, no dude en comunicarse con la instituci贸n.</p>
+                    <p style="margin-top: 20px;">Por favor, le solicitamos se regularice la situaci髇 a la brevedad. Si ya ha realizado el pago por otro medio, por favor env韊 el comprobante por este medio o por correo para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.</p>
+                    <p>Ante cualquier consulta, no dude en comunicarse con la instituci髇.</p>
 
                     <hr style="border: 0; border-top: 1px solid #eee; margin: 20px 0;">
                     <p style="font-size: 12px; color: #999; text-align: center;">' . $nombre_institucion . ' - Sistema de Gestion de Escuelas</p>
@@ -238,17 +249,17 @@ class envio_correo
 
     public static function generar_cuerpo_notificacion_cargos_multiples($datos)
     {
-        $tutor = htmlspecialchars($datos['tutor']);
-        $nombre_institucion = htmlspecialchars($datos['nombre_institucion']);
+        $tutor = htmlspecialchars($datos['tutor'], ENT_QUOTES, 'ISO-8859-1');
+        $nombre_institucion = htmlspecialchars($datos['nombre_institucion'], ENT_QUOTES, 'ISO-8859-1');
 
         $alumnos_html = '';
         foreach ($datos['alumnos'] as $al) {
-            $alumno = htmlspecialchars($al['alumno']);
-            $cargo_nombre = htmlspecialchars($al['cargo_nombre']);
-            $descripcion = htmlspecialchars($al['descripcion']);
-            $importe = htmlspecialchars($al['importe']);
-            $fecha = htmlspecialchars($al['fecha_generacion']);
-            $periodo = htmlspecialchars($al['periodo']);
+            $alumno = htmlspecialchars($al['alumno'], ENT_QUOTES, 'ISO-8859-1');
+            $cargo_nombre = htmlspecialchars($al['cargo_nombre'], ENT_QUOTES, 'ISO-8859-1');
+            $descripcion = htmlspecialchars($al['descripcion'], ENT_QUOTES, 'ISO-8859-1');
+            $importe = htmlspecialchars($al['importe'], ENT_QUOTES, 'ISO-8859-1');
+            $fecha = htmlspecialchars($al['fecha_generacion'], ENT_QUOTES, 'ISO-8859-1');
+            $periodo = htmlspecialchars($al['periodo'], ENT_QUOTES, 'ISO-8859-1');
 
             $detalle_deuda = '';
             if (!empty($al['detalle_deuda'])) {
@@ -267,10 +278,10 @@ class envio_correo
                 foreach ($al['detalle_deuda'] as $deuda) {
                     $detalle_deuda .= '
                             <tr>
-                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['concepto']) . '</td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['periodo']) . '</td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">$ ' . htmlspecialchars($deuda['importe']) . '</td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['estado']) . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['concepto'], ENT_QUOTES, 'ISO-8859-1') . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['periodo'], ENT_QUOTES, 'ISO-8859-1') . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">$ ' . htmlspecialchars($deuda['importe'], ENT_QUOTES, 'ISO-8859-1') . '</td>
+                                <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($deuda['estado'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                             </tr>';
                 }
                 $detalle_deuda .= '
@@ -285,20 +296,20 @@ class envio_correo
                     <table style="width: 100%; border-collapse: collapse; margin: 10px 0;">
                         <tr>
                             <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Medio de Pago:</strong></td>
-                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['medio_pago']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['medio_pago'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                         </tr>';
                 if (!empty($al['forma_pago']['marca_tarjeta'])) {
                     $forma_pago .= '
                         <tr>
                             <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Marca:</strong></td>
-                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['marca_tarjeta']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['marca_tarjeta'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                         </tr>';
                 }
                 if (!empty($al['forma_pago']['entidad_bancaria'])) {
                     $forma_pago .= '
                         <tr>
                             <td style="padding: 8px; border: 1px solid #ddd; background-color: #f9f9f9;"><strong>Banco/Entidad:</strong></td>
-                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['entidad_bancaria']) . '</td>
+                            <td style="padding: 8px; border: 1px solid #ddd;">' . htmlspecialchars($al['forma_pago']['entidad_bancaria'], ENT_QUOTES, 'ISO-8859-1') . '</td>
                         </tr>';
                 }
                 $forma_pago .= '
@@ -347,8 +358,8 @@ class envio_correo
 
                     ' . $alumnos_html . '
 
-                    <p style="margin-top: 20px;">Por favor, le solicitamos se regularice la situaci贸n a la brevedad. Si ya ha realizado el pago por otro medio, por favor env铆e el comprobante por este medio o por correo para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.</p>
-                    <p>Ante cualquier consulta, no dude en comunicarse con la instituci贸n.</p>
+                    <p style="margin-top: 20px;">Por favor, le solicitamos se regularice la situaci髇 a la brevedad. Si ya ha realizado el pago por otro medio, por favor env韊 el comprobante por este medio o por correo para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.</p>
+                    <p>Ante cualquier consulta, no dude en comunicarse con la instituci髇.</p>
 
                     <hr style="border: 0; border-top: 1px solid #eee; margin: 20px 0;">
                     <p style="font-size: 12px; color: #999; text-align: center;">' . $nombre_institucion . ' - Sistema de Gestion de Escuelas</p>
@@ -367,11 +378,20 @@ class envio_correo
         $tutor = $datos['tutor'];
 
         $meses = array(
-            '01' => 'Enero', '02' => 'Febrero', '03' => 'Marzo', '04' => 'Abril',
-            '05' => 'Mayo', '06' => 'Junio', '07' => 'Julio', '08' => 'Agosto',
-            '09' => 'Septiembre', '10' => 'Octubre', '11' => 'Noviembre', '12' => 'Diciembre'
+            '01' => 'Enero',
+            '02' => 'Febrero',
+            '03' => 'Marzo',
+            '04' => 'Abril',
+            '05' => 'Mayo',
+            '06' => 'Junio',
+            '07' => 'Julio',
+            '08' => 'Agosto',
+            '09' => 'Septiembre',
+            '10' => 'Octubre',
+            '11' => 'Noviembre',
+            '12' => 'Diciembre'
         );
-        
+
         $mes_nro = substr($cuota_raw, 0, 2);
         $anio = substr($cuota_raw, 2);
         $mes_nombre = (isset($meses[$mes_nro])) ? $meses[$mes_nro] : 'Mes ' . $mes_nro;
@@ -381,11 +401,10 @@ class envio_correo
         $mensaje .= "Estimado/a *{$tutor}*\n\n";
         $mensaje .= "Le informamos que el debito automatico correspondiente a la cuota del alumno/a *{$alumno}* ha sido rechazado por la entidad bancaria.\n\n";
         $mensaje .= "*Detalle:*\n";
-        $mensaje .= "- *Cuota (Mes/A帽o):* {$cuota}\n";
+        $mensaje .= "- *Cuota (Mes/A駉):* {$cuota}\n";
         $mensaje .= "- *Motivo:* {$error}\n\n";
         $mensaje .= "Por favor, le solicitamos se regularice la situacion a la brevedad. Si ya ha realizado el pago por otro medio, por favor *envie el comprobante por este medio o por correo* para que podamos registrarlo correctamente, ya que en ocasiones se realiza el pago pero no recibimos la constancia necesaria.";
 
         return $mensaje;
     }
 }
-?>

--- a/php/utiles/procesar_comprobantes_pendientes.php
+++ b/php/utiles/procesar_comprobantes_pendientes.php
@@ -1,0 +1,333 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Emite los comprobantes AFIP que quedaron encolados en comprobante_pendiente.
+ *
+ * Para correrlo a mano:
+ *
+ *     php php/utiles/procesar_comprobantes_pendientes.php
+ *
+ * Como se agenda en el cron: ver el bloque que sigue al cierre de este
+ * comentario. Va aparte porque una linea de crontab lleva barra-asterisco y eso
+ * cerraria este bloque.
+ *
+ * Por que existe: hoy persona::grabar_pago_persona() graba el pago y despues
+ * llama a AFIP por red, todo suelto. Si AFIP falla queda el pago sin
+ * comprobante; si AFIP responde bien y falla el UPDATE posterior, AFIP emitio
+ * una factura que la base no sabe que existe. Y mientras AFIP tarda, el
+ * operador espera.
+ *
+ * Con la cola, quien registra el pago solo encola —en la misma transaccion que
+ * el pago— y la emision se hace aca, con reintento y sin frenar a nadie.
+ *
+ * ---------------------------------------------------------------------------
+ * POR QUE NO SE PARECE AL CRON DE CORREOS
+ * ---------------------------------------------------------------------------
+ * El cron de correos toma el lote entero dentro de una transaccion y la cierra
+ * al final. Aca eso seria un error: emitir en AFIP NO SE PUEDE DESHACER. Si el
+ * lote se abortara a mitad de camino, se revertirian los UPDATE de comprobantes
+ * que AFIP ya emitio, y quedarian facturas reales que la base no registra.
+ *
+ * Por eso cada comprobante se maneja en tres pasos, cada uno con su propia
+ * transaccion:
+ *
+ *   1. RECLAMAR  - se marca la fila como 'EN' (en curso) y se commitea. Desde
+ *                  ese momento ninguna otra corrida la toma.
+ *   2. EMITIR    - la llamada a AFIP se hace FUERA de toda transaccion.
+ *   3. REGISTRAR - se guarda el resultado y se commitea.
+ *
+ * Si el proceso muere entre 2 y 3, la fila queda en 'EN'. Eso es a proposito:
+ * NO se reintenta sola, porque AFIP pudo haber emitido la factura y reintentar
+ * la emitiria dos veces. Una fila en 'EN' pide que alguien consulte en AFIP si
+ * el comprobante salio y la cierre a mano. Es el unico estado que no se
+ * resuelve automaticamente, y tiene que ser asi.
+ *
+ * Ademas se guarda el CAE y su vencimiento, que hoy no se guardan en ningun
+ * lado: transaccion_cuenta_corriente solo tiene punto_venta, comprobante_tipo y
+ * comprobante_numero. Por eso descargar_compobante.php le pide los datos a AFIP
+ * cada vez que arma un PDF, y si AFIP esta caido no se puede reimprimir nada.
+ */
+
+// ---------------------------------------------------------------------------
+// COMO SE AGENDA — crontab del servidor, no del repo
+// ---------------------------------------------------------------------------
+//
+//   # Emite los comprobantes AFIP encolados. Cada 15 minutos alcanza: los pagos
+//   # se encolan de a uno y el lote es de 20 por corrida.
+//   */15 * * * * TOBA_DIR=/data/local/sistema TOBA_INSTANCIA=produccion TOBA_PROYECTO=gestionescuelas php /data/local/sistema/proyectos/gestionescuelas/php/utiles/procesar_comprobantes_pendientes.php >> /var/log/gestionescuelas/comprobantes.log 2>&1
+//
+// Las tres variables ya tienen valor por defecto adentro del script
+// (/data/local/sistema, desarrollo, gestionescuelas). Se pasan explicitas para
+// que la linea del crontab deje asentado contra que instancia corre: es el dato
+// que despues nadie encuentra.
+//
+// Ajustar la ruta si TOBA_DIR no es /data/local/sistema. El proyecto siempre
+// cuelga de $TOBA_DIR/proyectos/$TOBA_PROYECTO.
+//
+// Codigos de salida: 0 si salio todo bien, 1 si algo fallo o quedo trabado, para
+// que el cron avise sin que nadie tenga que mirar el log.
+//
+// Es seguro que dos corridas se solapen: la segunda no toca lo que la primera ya
+// reclamo. Ver el estado 'EN' mas abajo.
+
+if (!isset($_SERVER['TOBA_DIR'])) {
+    $_SERVER['TOBA_DIR'] = '/data/local/sistema';
+}
+if (!isset($_SERVER['TOBA_INSTANCIA'])) {
+    $_SERVER['TOBA_INSTANCIA'] = 'desarrollo';
+}
+if (!isset($_SERVER['TOBA_PROYECTO'])) {
+    $_SERVER['TOBA_PROYECTO'] = 'gestionescuelas';
+}
+
+$dir = $_SERVER['TOBA_DIR'] . '/php';
+$separador = ':.:';
+ini_set('include_path', ini_get('include_path') . $separador . $dir);
+require_once('nucleo/toba_nucleo.php');
+
+toba_nucleo::instancia()->iniciar_contexto_desde_consola(
+    $_SERVER['TOBA_INSTANCIA'],
+    $_SERVER['TOBA_PROYECTO']
+);
+
+define('MAX_INTENTOS', 3);
+define('TAMANO_LOTE', 20);
+define('TIPO_COMPROBANTE', 11); // Factura C
+
+if (dao_consultas::catalogo_de_parametros('genera_comprobante_afip') != 'SI') {
+    toba::logger()->info('[comprobante_pendiente] La emision de comprobantes esta desactivada por parametro.');
+    toba::logger()->guardar();
+    return;
+}
+
+$afip_wrapper = new Afip();
+if (!$afip_wrapper->getAfip()) {
+    toba::logger()->error('[comprobante_pendiente] AFIP no esta configurado. No se procesa nada.');
+    toba::logger()->guardar();
+    exit(1);
+}
+
+$factura_electronica = new \SIU\Afip\WebService\FacturaElectronica($afip_wrapper->getAfip());
+$punto_venta = (int) dao_consultas::catalogo_de_parametros('punto_venta');
+
+$emitidos = 0;
+$fallidos = 0;
+$agotados = 0;
+$en_curso = 0;
+
+//Si quedaron filas trabadas de una corrida anterior, se avisa y no se tocan.
+$trabadas = toba::db()->consultar(
+    "SELECT id_comprobante_pendiente, id_transaccion_cc
+     FROM comprobante_pendiente
+     WHERE procesado = 'EN'"
+);
+
+if (!empty($trabadas)) {
+    foreach ($trabadas as $t) {
+        toba::logger()->error(
+            "[TRABADO] El comprobante id={$t['id_comprobante_pendiente']} (transaccion {$t['id_transaccion_cc']}) " .
+            "quedo en curso en una corrida anterior. Hay que consultar en AFIP si el comprobante se emitio " .
+            "antes de reintentarlo: reintentar a ciegas puede facturar dos veces."
+        );
+    }
+    $en_curso = count($trabadas);
+}
+
+//Candidatos. El lote real se decide fila por fila al reclamarlas.
+$candidatos = toba::db()->consultar(
+    "SELECT id_comprobante_pendiente
+     FROM comprobante_pendiente
+     WHERE procesado = 'NO' AND intentos < " . MAX_INTENTOS . "
+     ORDER BY fecha_alta ASC
+     LIMIT " . TAMANO_LOTE
+);
+
+if (empty($candidatos)) {
+    toba::logger()->info('[comprobante_pendiente] No hay comprobantes pendientes de emitir.');
+    toba::logger()->guardar();
+    exit($en_curso > 0 ? 1 : 0);
+}
+
+foreach ($candidatos as $candidato) {
+    $id = (int) $candidato['id_comprobante_pendiente'];
+
+    // ---- 1. RECLAMAR ------------------------------------------------------
+    // El SKIP LOCKED evita esperar a otra corrida que ya la tenga; el estado
+    // 'EN' commiteado evita que la tome despues.
+    $p = null;
+
+    toba::db()->abrir_transaccion();
+    try {
+        $filas = toba::db()->consultar(
+            "SELECT id_comprobante_pendiente
+                   ,id_transaccion_cc
+                   ,identificador_tutor
+                   ,importe
+                   ,intentos
+                   ,to_char(fecha_servicio_desde, 'YYYYMMDD') AS fecha_desde
+                   ,to_char(fecha_servicio_hasta, 'YYYYMMDD') AS fecha_hasta
+             FROM comprobante_pendiente
+             WHERE id_comprobante_pendiente = " . $id . "
+               AND procesado = 'NO'
+               AND intentos < " . MAX_INTENTOS . "
+             FOR UPDATE SKIP LOCKED"
+        );
+
+        if (empty($filas)) {
+            //Otra corrida la tomo primero.
+            toba::db()->cerrar_transaccion();
+            continue;
+        }
+
+        $p = $filas[0];
+
+        toba::db()->ejecutar(
+            "UPDATE comprobante_pendiente
+             SET procesado = 'EN', intentos = intentos + 1
+             WHERE id_comprobante_pendiente = " . $id
+        );
+
+        toba::db()->cerrar_transaccion();
+    } catch (Exception $e) {
+        toba::db()->abortar_transaccion();
+        toba::logger()->error("[ERR] No se pudo reclamar el comprobante id={$id}: " . $e->getMessage());
+        $fallidos++;
+        continue;
+    }
+
+    // ---- 2. EMITIR --------------------------------------------------------
+    // Fuera de toda transaccion. Es la parte que no se puede deshacer.
+    $comprobante = null;
+    $error_emision = null;
+
+    try {
+        //Un cargo sin cuota —materiales— no trae periodo de servicio. Se usa el
+        //mes corriente, que es lo que hace el origen.
+        $fecha_desde = !empty($p['fecha_desde']) ? $p['fecha_desde'] : date('Ym') . '01';
+        $fecha_hasta = !empty($p['fecha_hasta']) ? $p['fecha_hasta'] : date('Ymd', strtotime('last day of this month'));
+
+        $importe = (float) $p['importe'];
+        if ($importe <= 0) {
+            throw new Exception('El importe a facturar tiene que ser mayor a cero.');
+        }
+        if (empty($p['identificador_tutor'])) {
+            throw new Exception('El alumno no tiene tutor con documento: AFIP necesita el DocNro.');
+        }
+
+        $data = array(
+            'CantReg'      => 1,
+            'PtoVta'       => $punto_venta,
+            'CbteTipo'     => TIPO_COMPROBANTE,
+            'Concepto'     => 2,   // Servicios
+            'DocTipo'      => 96,  // DNI
+            'DocNro'       => $p['identificador_tutor'],
+            'FchServDesde' => intval($fecha_desde),
+            'FchServHasta' => intval($fecha_hasta),
+            'FchVtoPago'   => intval(date('Ymd')),
+            'CbteDesde'    => 1,
+            'CbteHasta'    => 1,
+            'CbteFch'      => intval(date('Ymd')),
+            'ImpTotal'     => $importe,
+            'ImpTotConc'   => 0,
+            'ImpNeto'      => $importe,
+            'ImpOpEx'      => 0,
+            'ImpIVA'       => 0,
+            'ImpTrib'      => 0,
+            'MonId'        => 'PES',
+            'MonCotiz'     => 1,
+        );
+
+        $comprobante = $factura_electronica->crearProximoComprobante($data);
+
+        if (!isset($comprobante['voucher_number'])) {
+            throw new Exception('AFIP no devolvio el numero de comprobante.');
+        }
+    } catch (Exception $e) {
+        $error_emision = substr($e->getMessage(), 0, 2000);
+    }
+
+    // ---- 3. REGISTRAR -----------------------------------------------------
+    if ($error_emision !== null) {
+        //AFIP no emitio: la fila vuelve a 'NO' para que se reintente. El
+        //intento ya se conto al reclamarla.
+        toba::db()->abrir_transaccion();
+        try {
+            toba::db()->ejecutar(
+                "UPDATE comprobante_pendiente
+                 SET procesado = 'NO', ultimo_error = " . toba::db()->quote($error_emision) . "
+                 WHERE id_comprobante_pendiente = " . $id
+            );
+            toba::db()->cerrar_transaccion();
+        } catch (Exception $e) {
+            toba::db()->abortar_transaccion();
+            toba::logger()->error("[ERR] No se pudo registrar el fallo del comprobante id={$id}: " . $e->getMessage());
+        }
+
+        if (((int) $p['intentos'] + 1) >= MAX_INTENTOS) {
+            $agotados++;
+        }
+
+        toba::logger()->error("[ERR] Fallo el comprobante de la transaccion {$p['id_transaccion_cc']} (id={$id}): {$error_emision}");
+        $fallidos++;
+        continue;
+    }
+
+    $numero = (int) $comprobante['voucher_number'];
+    $cae = isset($comprobante['CAE']) ? $comprobante['CAE'] : null;
+    $cae_vto = isset($comprobante['CAEFchVto']) ? $comprobante['CAEFchVto'] : null;
+
+    toba::db()->abrir_transaccion();
+    try {
+        toba::db()->ejecutar(
+            "UPDATE comprobante_pendiente
+             SET procesado          = 'SI'
+                ,fecha_procesado    = CURRENT_TIMESTAMP
+                ,ultimo_error       = NULL
+                ,punto_venta        = " . $punto_venta . "
+                ,comprobante_tipo   = " . TIPO_COMPROBANTE . "
+                ,comprobante_numero = " . $numero . "
+                ,cae                = " . toba::db()->quote($cae) . "
+                ,cae_vencimiento    = " . ($cae_vto ? toba::db()->quote($cae_vto) : 'NULL') . "
+             WHERE id_comprobante_pendiente = " . $id
+        );
+
+        //Se sigue escribiendo en transaccion_cuenta_corriente para que el resto
+        //del sistema —la cuenta corriente del tutor, el PDF— funcione igual.
+        toba::db()->ejecutar(
+            "UPDATE transaccion_cuenta_corriente
+             SET punto_venta        = " . $punto_venta . "
+                ,comprobante_tipo   = " . TIPO_COMPROBANTE . "
+                ,comprobante_numero = " . $numero . "
+             WHERE id_transaccion_cc = " . (int) $p['id_transaccion_cc']
+        );
+
+        toba::db()->cerrar_transaccion();
+
+        toba::logger()->info("[OK] Comprobante {$punto_venta}-{$numero} emitido para la transaccion {$p['id_transaccion_cc']} (CAE {$cae})");
+        $emitidos++;
+    } catch (Exception $e) {
+        toba::db()->abortar_transaccion();
+        //AFIP YA EMITIO y no se pudo registrar. La fila queda en 'EN' y hay que
+        //cerrarla a mano con los datos del comprobante que quedan en el log.
+        toba::logger()->error(
+            "[GRAVE] AFIP emitio el comprobante {$punto_venta}-{$numero} (CAE {$cae}) para la transaccion " .
+            "{$p['id_transaccion_cc']} pero NO se pudo guardar: " . $e->getMessage() . ". " .
+            "La fila id={$id} queda en curso y hay que cerrarla a mano con estos datos."
+        );
+        $fallidos++;
+        $en_curso++;
+    }
+}
+
+$resumen = "[comprobante_pendiente] Emitidos: {$emitidos}, fallidos: {$fallidos}";
+if ($agotados > 0) {
+    $resumen .= ", agotaron reintentos: {$agotados}";
+}
+if ($en_curso > 0) {
+    $resumen .= ", TRABADOS en curso: {$en_curso} (revisar en AFIP antes de reintentar)";
+}
+
+toba::logger()->info($resumen);
+toba::logger()->guardar();
+
+exit(($fallidos > 0 || $en_curso > 0) ? 1 : 0);

--- a/php/utiles/procesar_correos_pendientes.php
+++ b/php/utiles/procesar_correos_pendientes.php
@@ -1,5 +1,38 @@
 #!/usr/bin/env php
 <?php
+/**
+ * Envia los correos encolados en correo_pendiente.
+ *
+ * La generacion de cargos ya no manda los correos en el momento —con 137 tutores
+ * se iba en timeout— sino que los deja encolados. Este script los saca.
+ *
+ * Para correrlo a mano:
+ *
+ *     php php/utiles/procesar_correos_pendientes.php
+ *
+ * Como se agenda en el cron: ver el bloque que sigue al cierre de este
+ * comentario. Va aparte porque una linea de crontab lleva barra-asterisco y eso
+ * cerraria este bloque.
+ */
+
+// ---------------------------------------------------------------------------
+// COMO SE AGENDA — crontab del servidor, no del repo
+// ---------------------------------------------------------------------------
+//
+//   # Envia los avisos encolados al generar cargos.
+//   */5 * * * * TOBA_DIR=/data/local/sistema TOBA_INSTANCIA=produccion TOBA_PROYECTO=gestionescuelas php /data/local/sistema/proyectos/gestionescuelas/php/utiles/procesar_correos_pendientes.php >> /var/log/gestionescuelas/correos.log 2>&1
+//
+// Por que cada 5 minutos y no cada 15: el lote es de 20 correos por corrida y una
+// generacion de cargos encola mas de 130. A 5 minutos la cola se vacia en poco
+// mas de media hora; a 15 tardaria casi dos.
+//
+// Las tres variables ya tienen valor por defecto abajo (/data/local/sistema,
+// desarrollo, gestionescuelas). Se pasan explicitas para que la linea del
+// crontab deje asentado contra que instancia corre: es el dato que despues nadie
+// encuentra.
+//
+// Ajustar la ruta si TOBA_DIR no es /data/local/sistema. El proyecto siempre
+// cuelga de $TOBA_DIR/proyectos/$TOBA_PROYECTO.
 
 if (!isset($_SERVER['TOBA_DIR'])) {
     $_SERVER['TOBA_DIR'] = '/data/local/sistema';

--- a/php/utiles/procesar_correos_pendientes.php
+++ b/php/utiles/procesar_correos_pendientes.php
@@ -1,0 +1,69 @@
+#!/usr/bin/env php
+<?php
+
+if (!isset($_SERVER['TOBA_DIR'])) {
+    $_SERVER['TOBA_DIR'] = '/data/local/sistema';
+}
+if (!isset($_SERVER['TOBA_INSTANCIA'])) {
+    $_SERVER['TOBA_INSTANCIA'] = 'desarrollo';
+}
+if (!isset($_SERVER['TOBA_PROYECTO'])) {
+    $_SERVER['TOBA_PROYECTO'] = 'gestionescuelas';
+}
+
+$dir = $_SERVER['TOBA_DIR'] . '/php';
+$separador = ':.:';
+ini_set('include_path', ini_get('include_path') . $separador . $dir);
+require_once('nucleo/toba_nucleo.php');
+
+toba_nucleo::instancia()->iniciar_contexto_desde_consola(
+    $_SERVER['TOBA_INSTANCIA'],
+    $_SERVER['TOBA_PROYECTO']
+);
+
+$pendientes = toba::db()->consultar(
+    "SELECT * FROM correo_pendiente
+     WHERE procesado = 'NO' AND intentos < 3
+     ORDER BY fecha_alta ASC
+     LIMIT 20"
+);
+
+if (empty($pendientes)) {
+    toba::logger()->info('[correo_pendiente] No hay correos pendientes para procesar.');
+    return;
+}
+
+$procesados = 0;
+$fallidos = 0;
+
+foreach ($pendientes as $p) {
+    try {
+        $mail = new envio_correo($p['email_destino']);
+        $mail->set_asunto($p['asunto']);
+        $mail->set_cuerpo($p['cuerpo']);
+        $mail->enviar();
+
+        toba::db()->consultar(
+            "UPDATE correo_pendiente
+             SET procesado = 'SI', fecha_procesado = CURRENT_TIMESTAMP
+             WHERE id_correo_pendiente = " . (int)$p['id_correo_pendiente']
+        );
+
+        toba::logger()->info("[OK] Correo enviado a {$p['email_destino']} (id={$p['id_correo_pendiente']})");
+        $procesados++;
+    } catch (Exception $e) {
+        $error_msg = toba::db()->quote($e->getMessage());
+        toba::db()->consultar(
+            "UPDATE correo_pendiente
+             SET intentos = intentos + 1,
+                 ultimo_error = {$error_msg}
+             WHERE id_correo_pendiente = " . (int)$p['id_correo_pendiente']
+        );
+
+        toba::logger()->info("[ERR] Fallo correo a {$p['email_destino']} (id={$p['id_correo_pendiente']}): {$e->getMessage()}");
+        $fallidos++;
+    }
+}
+
+toba::logger()->info("[correo_pendiente] Procesados: {$procesados}, Fallidos: {$fallidos}");
+toba::logger()->guardar();

--- a/sql/conversion/borrar_procedures.sql
+++ b/sql/conversion/borrar_procedures.sql
@@ -84,3 +84,9 @@ DROP FUNCTION IF EXISTS generacion_de_comprobantes_afip_desde_alta_pagos();
 
 --Alejandro feature/generacion-de-comprobantes-afip-desde-el-alta-de-pagos 23/02/2024
 DROP FUNCTION IF EXISTS correcciones_varias_perfil_administrativo();
+
+--Agregar parametros de notificacion al generar cargo 15/07/2026
+DROP FUNCTION IF EXISTS altas_parametros_notificacion_cargos();
+
+--Alejandro feature/generacion-de-cargos-notificaciones 16/07/2026
+DROP FUNCTION IF EXISTS altas_tabla_correo_pendiente();

--- a/sql/conversion/borrar_procedures.sql
+++ b/sql/conversion/borrar_procedures.sql
@@ -90,3 +90,6 @@ DROP FUNCTION IF EXISTS altas_parametros_notificacion_cargos();
 
 --Alejandro feature/generacion-de-cargos-notificaciones 16/07/2026
 DROP FUNCTION IF EXISTS altas_tabla_correo_pendiente();
+
+--Alejandro feature/enviar-correo-electronico-al-generar-cargos 03/08/2026
+DROP FUNCTION IF EXISTS altas_tabla_comprobante_pendiente();

--- a/sql/conversion/crear_procedures.sql
+++ b/sql/conversion/crear_procedures.sql
@@ -1136,3 +1136,43 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE 'plpgsql';
+
+
+--Alejandro feature/enviar-correo-electronico-al-generar-cargos 03/08/2026
+--Cola de comprobantes AFIP pendientes de emitir. Mismo patron que correo_pendiente:
+--el pago se graba y commitea, y la emision queda encolada para hacerla aparte con
+--reintento. El UNIQUE sobre id_transaccion_cc impide que un pago termine con dos
+--facturas. Las columnas cae y cae_vencimiento guardan lo que hoy vive solo en AFIP.
+CREATE OR REPLACE FUNCTION altas_tabla_comprobante_pendiente() RETURNS VOID AS
+$$
+BEGIN
+    IF NOT EXISTS ( SELECT '' FROM information_schema.tables WHERE table_name = 'comprobante_pendiente') THEN
+
+        CREATE TABLE comprobante_pendiente (
+            id_comprobante_pendiente SERIAL PRIMARY KEY,
+            id_transaccion_cc        INTEGER       NOT NULL UNIQUE
+                                                   REFERENCES transaccion_cuenta_corriente (id_transaccion_cc),
+            id_alumno_cc             INTEGER       NOT NULL
+                                                   REFERENCES alumno_cuenta_corriente (id_alumno_cc),
+            identificador_tutor      VARCHAR(20),
+            importe                  NUMERIC(15,2) NOT NULL,
+            fecha_servicio_desde     DATE,
+            fecha_servicio_hasta     DATE,
+            fecha_alta               TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+            procesado                CHAR(2)       DEFAULT 'NO',
+            fecha_procesado          TIMESTAMP,
+            intentos                 INTEGER       DEFAULT 0,
+            ultimo_error             TEXT,
+            punto_venta              INTEGER,
+            comprobante_tipo         INTEGER,
+            comprobante_numero       INTEGER,
+            cae                      VARCHAR(20),
+            cae_vencimiento          DATE
+        );
+
+        CREATE INDEX idx_comprobante_pendiente_procesado ON comprobante_pendiente(procesado, intentos);
+        CREATE INDEX idx_comprobante_pendiente_fecha ON comprobante_pendiente(fecha_alta);
+
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql';

--- a/sql/conversion/crear_procedures.sql
+++ b/sql/conversion/crear_procedures.sql
@@ -1083,3 +1083,56 @@ BEGIN
     END IF;
 END;
 $$ LANGUAGE 'plpgsql';
+
+
+--Agregar parametros de notificacion al generar cargo 15/07/2026
+CREATE OR REPLACE FUNCTION altas_parametros_notificacion_cargos() RETURNS VOID AS
+$$
+BEGIN
+    IF NOT EXISTS ( SELECT '' FROM information_schema.columns WHERE table_name = 'cargo_cuenta_corriente' AND column_name = 'notifica_mail') THEN
+        ALTER TABLE cargo_cuenta_corriente
+            ADD COLUMN notifica_mail character(2) DEFAULT 'SI'::bpchar;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE parametro = 'envia_notif_al_generar_cargo') THEN
+        INSERT INTO parametros_sistema (id_parametro, parametro, descripcion, desc_corta, valor, version_publicacion)
+        VALUES (NEXTVAL('sq_id_parametro'), 'envia_notif_al_generar_cargo', 'Envia notificacion al tutor cuando se genera un cargo', 'Envia notif. al generar cargo', 'SI', '1.0.0');
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE parametro = 'envia_detalle_deuda_en_correo') THEN
+        INSERT INTO parametros_sistema (id_parametro, parametro, descripcion, desc_corta, valor, version_publicacion)
+        VALUES (NEXTVAL('sq_id_parametro'), 'envia_detalle_deuda_en_correo', 'Incluye detalle de deuda en el correo de notificacion de cargo', 'Incluye detalle deuda en correo', 'SI', '1.0.0');
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM parametros_sistema WHERE parametro = 'envia_forma_pago_en_correo') THEN
+        INSERT INTO parametros_sistema (id_parametro, parametro, descripcion, desc_corta, valor, version_publicacion)
+        VALUES (NEXTVAL('sq_id_parametro'), 'envia_forma_pago_en_correo', 'Incluye forma de pago en el correo de notificacion de cargo', 'Incluye forma pago en correo', 'SI', '1.0.0');
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql';
+
+
+--Alejandro feature/generacion-de-cargos-notificaciones 16/07/2026
+CREATE OR REPLACE FUNCTION altas_tabla_correo_pendiente() RETURNS VOID AS
+$$
+BEGIN
+    IF NOT EXISTS ( SELECT '' FROM information_schema.tables WHERE table_name = 'correo_pendiente') THEN
+
+        CREATE TABLE correo_pendiente (
+            id_correo_pendiente SERIAL PRIMARY KEY,
+            email_destino VARCHAR(255) NOT NULL,
+            asunto VARCHAR(255) NOT NULL,
+            cuerpo TEXT NOT NULL,
+            fecha_alta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            fecha_procesado TIMESTAMP,
+            procesado CHAR(2) DEFAULT 'NO',
+            intentos INTEGER DEFAULT 0,
+            ultimo_error TEXT
+        );
+
+        CREATE INDEX idx_correo_pendiente_procesado ON correo_pendiente(procesado);
+        CREATE INDEX idx_correo_pendiente_fecha ON correo_pendiente(fecha_alta);
+
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql';

--- a/sql/conversion/ejecutar_procedures.sql
+++ b/sql/conversion/ejecutar_procedures.sql
@@ -87,3 +87,6 @@ SELECT altas_parametros_notificacion_cargos();
 
 --Alejandro feature/generacion-de-cargos-notificaciones 16/07/2026
 SELECT altas_tabla_correo_pendiente();
+
+--Alejandro feature/enviar-correo-electronico-al-generar-cargos 03/08/2026
+SELECT altas_tabla_comprobante_pendiente();

--- a/sql/conversion/ejecutar_procedures.sql
+++ b/sql/conversion/ejecutar_procedures.sql
@@ -81,3 +81,9 @@ SELECT generacion_de_comprobantes_afip_desde_alta_pagos();
 
 --Alejandro feature/generacion-de-comprobantes-afip-desde-el-alta-de-pagos 23/02/2024
 SELECT correcciones_varias_perfil_administrativo();
+
+--Agregar parametros de notificacion al generar cargo 15/07/2026
+SELECT altas_parametros_notificacion_cargos();
+
+--Alejandro feature/generacion-de-cargos-notificaciones 16/07/2026
+SELECT altas_tabla_correo_pendiente();


### PR DESCRIPTION
…rgos mediante tabla correo_pendiente + cron

- Agrega funcion SQL altas_tabla_correo_pendiente() que crea la tabla correo_pendiente con indices para encolar correos de notificacion
- Modifica cn_generar_cargos_alumnos.php: tanto el modo Individual como el Grupal ahora insertan en correo_pendiente en vez de enviar el correo directamente, eliminando el timeout con 137+ tutores
- Crea php/utiles/procesar_correos_pendientes.php: script CLI para cron que envia 20 correos por ejecucion, marca como procesados los exitosos y reintenta hasta 3 veces los fallidos con registro del error
- Elimina metodos no utilizados get_deuda_resumida_por_alumno() y get_forma_pago_alumno() de dao_consultas.php (reemplazados por los existentes en la clase persona)
- Registra las nuevas funciones en borrar_procedures.sql y ejecutar_procedures.sql